### PR TITLE
モックで代用したデータ取得部分をRetrofitで実装

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
@@ -41,7 +41,7 @@ fun AppRoot() {
 
     NavHost(
         navController = navController,
-        startDestination = "repository/detail?repositoryName=xxx"
+        startDestination = "repository/search",
     ) {
         composable("repository/search") {
             RepositorySearchScreen()

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
@@ -45,7 +45,7 @@ fun AppRoot() {
     ) {
         composable("repository/search") {
             RepositorySearchScreen(
-                gotoRepositoryDetailScreen = { navController.navigate("repository/detail?repositoryName={${it.name}}") },
+                gotoRepositoryDetailScreen = { navController.navigate("repository/detail?repositoryName=${it.name}") },
             )
         }
         composable(

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/MainActivity.kt
@@ -44,7 +44,9 @@ fun AppRoot() {
         startDestination = "repository/search",
     ) {
         composable("repository/search") {
-            RepositorySearchScreen()
+            RepositorySearchScreen(
+                gotoRepositoryDetailScreen = { navController.navigate("repository/detail?repositoryName={${it.name}}") },
+            )
         }
         composable(
             route = "repository/detail?repositoryName={repositoryName}",

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/detail/RepositoryDetailScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/detail/RepositoryDetailScreen.kt
@@ -81,7 +81,7 @@ fun RepositoryDetailContent(
 
         Row {
             Text(
-                text = "Written in ${repository.language}",
+                text = if (repository.language != null) "Written in ${repository.language}" else "",
                 modifier = Modifier.weight(1f),
             )
             Column(Modifier.weight(1f), horizontalAlignment = Alignment.End) {

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/search/RepositorySearchScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/search/RepositorySearchScreen.kt
@@ -38,6 +38,7 @@ fun RepositorySearchScreen(
         searchQuery = text,
         onChangeSearchQuery = { searchViewModel.updateSearchQuery(it) },
         repositories = repositoriesUiState.repositories,
+        onSearchRepositories = { searchViewModel.searchRepository() },
         onClickRepository = { /* TODO goto detail page */ },
     )
 }
@@ -47,6 +48,7 @@ private fun RepositorySearchContent(
     searchQuery: String,
     onChangeSearchQuery: (String) -> Unit,
     repositories: List<GithubRepoData>?,
+    onSearchRepositories: () -> Unit,
     onClickRepository: (GithubRepoData) -> Unit,
 ) {
     Scaffold(
@@ -62,6 +64,7 @@ private fun RepositorySearchContent(
                 SearchBar(
                     value = searchQuery,
                     onValueChange = onChangeSearchQuery,
+                    onSearch = { onSearchRepositories() },
                 )
             }
             if (repositories.isNullOrEmpty()) {
@@ -106,6 +109,7 @@ fun RepositorySearchContentPreview(
             searchQuery = "kotlin",
             onChangeSearchQuery = {},
             repositories = repositories,
+            onSearchRepositories = {},
             onClickRepository = {},
         )
         Text("${isSystemInDarkTheme()}")

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/search/RepositorySearchScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/search/RepositorySearchScreen.kt
@@ -29,6 +29,7 @@ import jp.co.yumemi.android.code_check.theme.CodeCheckTheme
 @Composable
 fun RepositorySearchScreen(
     searchViewModel: RepositorySearchViewModel = hiltViewModel(),
+    gotoRepositoryDetailScreen: (GithubRepoData) -> Unit,
 ) {
     // 検証用
     val text by searchViewModel.searchQuery.collectAsState()
@@ -39,7 +40,7 @@ fun RepositorySearchScreen(
         onChangeSearchQuery = { searchViewModel.updateSearchQuery(it) },
         repositories = repositoriesUiState.repositories,
         onSearchRepositories = { searchViewModel.searchRepository() },
-        onClickRepository = { /* TODO goto detail page */ },
+        onClickRepository = { gotoRepositoryDetailScreen(it) },
     )
 }
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/search/SearchBar.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/search/SearchBar.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -24,6 +26,7 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
@@ -32,6 +35,7 @@ fun SearchBar(
     modifier: Modifier = Modifier,
     value: String,
     onValueChange: (String) -> Unit,
+    onSearch: () -> Unit,
 ) {
     var hasFocus by remember { mutableStateOf(false) }
 
@@ -60,6 +64,12 @@ fun SearchBar(
                 textStyle = TextStyle.Default.copy(color = textColor),
                 singleLine = true,
                 cursorBrush = SolidColor(textColor),
+                keyboardOptions = KeyboardOptions(
+                    imeAction = ImeAction.Search,
+                ),
+                keyboardActions = KeyboardActions(
+                    onSearch = { onSearch() },
+                ),
             )
             IconButton(
                 modifier = Modifier.alpha(if (hasFocus) 0.8f else 0f),
@@ -80,5 +90,6 @@ private fun SearchBarPreview() {
     SearchBar(
         value = "preview search bar",
         onValueChange = {},
+        onSearch = {},
     )
 }

--- a/github/build.gradle
+++ b/github/build.gradle
@@ -23,11 +23,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/github/build.gradle
+++ b/github/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     kapt "com.google.dagger:hilt-compiler:2.44"
 
     // retrofit
-    implementation 'com.squareup.retrofit2:retrofit2:2.9.0'
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-moshi:2.9.0'
 }
 

--- a/github/build.gradle
+++ b/github/build.gradle
@@ -43,6 +43,10 @@ dependencies {
     // hilt
     implementation "com.google.dagger:hilt-android:2.44"
     kapt "com.google.dagger:hilt-compiler:2.44"
+
+    // retrofit
+    implementation 'com.squareup.retrofit2:retrofit2:2.9.0'
+    implementation 'com.squareup.retrofit2:converter-moshi:2.9.0'
 }
 
 kapt {

--- a/github/src/main/java/jp/co/yumemi/android/code_check/github/model/GithubRepoData.kt
+++ b/github/src/main/java/jp/co/yumemi/android/code_check/github/model/GithubRepoData.kt
@@ -2,8 +2,8 @@ package jp.co.yumemi.android.code_check.github.model
 
 data class GithubRepoData(
     val name: String,
-    val ownerIconUrl: String,
-    val language: String,
+    val ownerIconUrl: String?,
+    val language: String?,
     val stargazersCount: Long,
     val watchersCount: Long,
     val forksCount: Long,

--- a/github/src/main/java/jp/co/yumemi/android/code_check/github/model/GithubRepoDataRepository.kt
+++ b/github/src/main/java/jp/co/yumemi/android/code_check/github/model/GithubRepoDataRepository.kt
@@ -2,15 +2,17 @@ package jp.co.yumemi.android.code_check.github.model
 
 import javax.inject.Inject
 
-class GithubRepoDataRepository @Inject constructor() {
+class GithubRepoDataRepository @Inject constructor(
+    private val githubRepoService: GithubRepoService,
+) {
     private var repositoriesCache = listOf<GithubRepoData>()
     suspend fun searchRepositories(searchQuery: String): List<GithubRepoData> {
-        val repositories = listOf(
-            exampleGithubRepoData,
-        )
-        return repositories.also {
+        val repositories = githubRepoService.search(searchQuery)
+            .body()?.items
+            ?.map { it.toGithubRepoData() }
+        return repositories?.also {
             cacheRepositories(it)
-        }
+        } ?: emptyList()
     }
 
     private suspend fun cacheRepositories(repoData: List<GithubRepoData>) {

--- a/github/src/main/java/jp/co/yumemi/android/code_check/github/model/GithubRepoDataRepository.kt
+++ b/github/src/main/java/jp/co/yumemi/android/code_check/github/model/GithubRepoDataRepository.kt
@@ -1,10 +1,17 @@
 package jp.co.yumemi.android.code_check.github.model
 
+import android.util.Log
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class GithubRepoDataRepository @Inject constructor(
     private val githubRepoService: GithubRepoService,
 ) {
+    init {
+        Log.d("github-repo-data-repository", "init")
+    }
+
     private var repositoriesCache = listOf<GithubRepoData>()
     suspend fun searchRepositories(searchQuery: String): List<GithubRepoData> {
         val repositories = githubRepoService.search(searchQuery)
@@ -21,6 +28,10 @@ class GithubRepoDataRepository @Inject constructor(
 
     suspend fun getRepoData(repositoryName: String): GithubRepoData? {
         val repoInCache = repositoriesCache.firstOrNull { it.name == repositoryName }
+        Log.d(
+            "github-repo-data-repository",
+            "get $repositoryName from ${repositoriesCache.joinToString(" , ") { it.name }}"
+        )
         if (repoInCache != null) return repoInCache
         TODO("not implement, fetch repository by repositoryName")
     }

--- a/github/src/main/java/jp/co/yumemi/android/code_check/github/model/GithubRepoDataRepository.kt
+++ b/github/src/main/java/jp/co/yumemi/android/code_check/github/model/GithubRepoDataRepository.kt
@@ -14,6 +14,7 @@ class GithubRepoDataRepository @Inject constructor(
 
     private var repositoriesCache = listOf<GithubRepoData>()
     suspend fun searchRepositories(searchQuery: String): List<GithubRepoData> {
+        Log.d("search repositories", "${githubRepoService.search(searchQuery).body()}")
         val repositories = githubRepoService.search(searchQuery)
             .body()?.items
             ?.map { it.toGithubRepoData() }

--- a/github/src/main/java/jp/co/yumemi/android/code_check/github/model/GithubRepoModule.kt
+++ b/github/src/main/java/jp/co/yumemi/android/code_check/github/model/GithubRepoModule.kt
@@ -1,0 +1,35 @@
+package jp.co.yumemi.android.code_check.github.model
+
+import com.squareup.moshi.Moshi
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+
+@Module
+@InstallIn(SingletonComponent::class)
+object GithubRepoModule {
+    @Provides
+    fun provideGithubRepoService(
+        retrofit: Retrofit,
+    ): GithubRepoService {
+        return retrofit.create(GithubRepoService::class.java)
+    }
+
+    @Provides
+    fun provideRetrofit(moshi: Moshi): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl("https://api.github.com/")
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .build()
+    }
+
+    @Provides
+    fun provideMoshi(): Moshi {
+        return Moshi.Builder().build()
+    }
+
+
+}

--- a/github/src/main/java/jp/co/yumemi/android/code_check/github/model/GithubRepoService.kt
+++ b/github/src/main/java/jp/co/yumemi/android/code_check/github/model/GithubRepoService.kt
@@ -1,0 +1,47 @@
+package jp.co.yumemi.android.code_check.github.model
+
+import com.squareup.moshi.Json
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Headers
+import retrofit2.http.Query
+
+interface GithubRepoService {
+    @GET("search/repositories")
+    @Headers("Accept: application/vnd.github.v3+json")
+    suspend fun search(@Query("q") searchQuery: String): Response<SearchResponse>
+
+    data class SearchResponse(
+        val items: List<RepoData>
+    )
+
+    data class RepoData(
+        val name: String,
+        val owner: Owner,
+        val language: String,
+        @Json(name = "stargazers_count")
+        val stargazersCount: Long,
+        @Json(name = "watchers_count")
+        val watchersCount: Long,
+        @Json(name = "forks_count")
+        val forksCount: Long,
+        @Json(name = "open_issues_count")
+        val openIssuesCount: Long,
+    ) {
+        data class Owner(
+            @Json(name = "avatar_url")
+            val avatarUrl: String,
+        )
+
+        fun toGithubRepoData(): GithubRepoData =
+            GithubRepoData(
+                name = this.name,
+                ownerIconUrl = this.owner.avatarUrl,
+                language = this.language,
+                stargazersCount = this.stargazersCount,
+                watchersCount = this.watchersCount,
+                forksCount = this.forksCount,
+                openIssuesCount = this.openIssuesCount,
+            )
+    }
+}

--- a/github/src/main/java/jp/co/yumemi/android/code_check/github/model/GithubRepoService.kt
+++ b/github/src/main/java/jp/co/yumemi/android/code_check/github/model/GithubRepoService.kt
@@ -1,5 +1,6 @@
 package jp.co.yumemi.android.code_check.github.model
 
+import android.util.Log
 import com.squareup.moshi.Json
 import retrofit2.Response
 import retrofit2.http.GET
@@ -12,36 +13,41 @@ interface GithubRepoService {
     suspend fun search(@Query("q") searchQuery: String): Response<SearchResponse>
 
     data class SearchResponse(
-        val items: List<RepoData>
+        val items: List<RepoData>,
     )
 
     data class RepoData(
         val name: String,
         val owner: Owner,
         val language: String,
-        @Json(name = "stargazers_count")
+        @field:Json(name = "stargazers_count")
         val stargazersCount: Long,
-        @Json(name = "watchers_count")
+        @field:Json(name = "watchers_count")
         val watchersCount: Long,
-        @Json(name = "forks_count")
+        @field:Json(name = "forks_count")
         val forksCount: Long,
-        @Json(name = "open_issues_count")
+        @field:Json(name = "open_issues_count")
         val openIssuesCount: Long,
     ) {
         data class Owner(
-            @Json(name = "avatar_url")
+            @field:Json(name = "avatar_url")
             val avatarUrl: String,
         )
 
-        fun toGithubRepoData(): GithubRepoData =
-            GithubRepoData(
+        fun toGithubRepoData(): GithubRepoData {
+            Log.d("convert", "$this")
+            return exampleGithubRepoData.copy(
                 name = this.name,
-                ownerIconUrl = this.owner.avatarUrl,
-                language = this.language,
-                stargazersCount = this.stargazersCount,
-                watchersCount = this.watchersCount,
-                forksCount = this.forksCount,
-                openIssuesCount = this.openIssuesCount,
             )
+        }
+//            GithubRepoData(
+//                name = this.name,
+//                ownerIconUrl = "https://tbsten.me/tbsten500x500.png",
+//                language = "",
+//                stargazersCount = this.stargazersCount,
+//                watchersCount = this.watchersCount,
+//                forksCount = this.forksCount,
+//                openIssuesCount = this.openIssuesCount,
+//            )
     }
 }

--- a/github/src/main/java/jp/co/yumemi/android/code_check/github/model/GithubRepoService.kt
+++ b/github/src/main/java/jp/co/yumemi/android/code_check/github/model/GithubRepoService.kt
@@ -1,6 +1,5 @@
 package jp.co.yumemi.android.code_check.github.model
 
-import android.util.Log
 import com.squareup.moshi.Json
 import retrofit2.Response
 import retrofit2.http.GET
@@ -35,19 +34,16 @@ interface GithubRepoService {
         )
 
         fun toGithubRepoData(): GithubRepoData {
-            Log.d("convert", "$this")
-            return exampleGithubRepoData.copy(
+            return GithubRepoData(
                 name = this.name,
+                ownerIconUrl = "https://tbsten.me/tbsten500x500.png",
+                language = "",
+                stargazersCount = this.stargazersCount,
+                watchersCount = this.watchersCount,
+                forksCount = this.forksCount,
+                openIssuesCount = this.openIssuesCount,
             )
+
         }
-//            GithubRepoData(
-//                name = this.name,
-//                ownerIconUrl = "https://tbsten.me/tbsten500x500.png",
-//                language = "",
-//                stargazersCount = this.stargazersCount,
-//                watchersCount = this.watchersCount,
-//                forksCount = this.forksCount,
-//                openIssuesCount = this.openIssuesCount,
-//            )
     }
 }

--- a/github/src/main/java/jp/co/yumemi/android/code_check/github/model/GithubRepoService.kt
+++ b/github/src/main/java/jp/co/yumemi/android/code_check/github/model/GithubRepoService.kt
@@ -1,5 +1,6 @@
 package jp.co.yumemi.android.code_check.github.model
 
+import android.util.Log
 import com.squareup.moshi.Json
 import retrofit2.Response
 import retrofit2.http.GET
@@ -17,8 +18,8 @@ interface GithubRepoService {
 
     data class RepoData(
         val name: String,
-        val owner: Owner,
-        val language: String,
+        val owner: Owner?,
+        val language: String?,
         @field:Json(name = "stargazers_count")
         val stargazersCount: Long,
         @field:Json(name = "watchers_count")
@@ -34,10 +35,11 @@ interface GithubRepoService {
         )
 
         fun toGithubRepoData(): GithubRepoData {
+            Log.d("to repo data", "${this}")
             return GithubRepoData(
                 name = this.name,
-                ownerIconUrl = "https://tbsten.me/tbsten500x500.png",
-                language = "",
+                ownerIconUrl = this.owner?.avatarUrl,
+                language = this.language,
                 stargazersCount = this.stargazersCount,
                 watchersCount = this.watchersCount,
                 forksCount = this.forksCount,


### PR DESCRIPTION
## 概要

モックで代用していたデータ取得部分をRetrofitで実装。

## 関連issue

(なし)

## 変更点

- retrofitを追加
- データ取得関連のクラスを追加
- View
- GithubRepoDataのフィールドの型を[GithubAPIの仕様](https://docs.github.com/ja/rest/search/search?apiVersion=2022-11-28#search-repositories)に合わせて変更。
