### PR TITLE
エラーハンドリングとローディング表示

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,6 +67,8 @@ dependencies {
     implementation "androidx.compose.ui:ui"
     implementation "androidx.compose.foundation:foundation"
     implementation "androidx.compose.material:material"
+    implementation "androidx.compose.material:material-icons-extended"
+
 
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/components/Alert.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/components/Alert.kt
@@ -1,4 +1,4 @@
-package jp.co.yumemi.android.code_check.repository.search
+package jp.co.yumemi.android.code_check.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/detail/RepositoryDetailScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/detail/RepositoryDetailScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
@@ -59,7 +61,8 @@ fun RepositoryDetailScreen(
 fun RepositoryDetailContent(
     repository: GithubRepoData,
 ) {
-    Column(Modifier.padding(horizontal = 8.dp)) {
+    val scrollState = rememberScrollState()
+    Column(Modifier.verticalScroll(scrollState).padding(horizontal = 8.dp)) {
         val imageModifier =
             Modifier
                 .padding(8.dp)

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/detail/RepositoryDetailScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/detail/RepositoryDetailScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
@@ -44,8 +45,11 @@ fun RepositoryDetailScreen(
         topBar = { RepositoryDetailTopBar(repositoryName) }
     ) {
         val repository = repositoryUiState.repository
+        val isLoading = repositoryUiState.isLoading
         Box(Modifier.padding(it)) {
-            if (repository == null) {
+            if (isLoading) {
+                RepositoryLoading()
+            } else if (repository == null) {
                 RepositoryNotFound()
             } else {
                 RepositoryDetailContent(
@@ -108,6 +112,13 @@ private fun RepositoryDetailTopBar(repositoryName: String?) {
 private fun RepositoryNotFound() {
     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Text("レポジトリが見つかりませんでした...")
+    }
+}
+
+@Composable
+private fun RepositoryLoading() {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
     }
 }
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/detail/RepositoryDetailViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/detail/RepositoryDetailViewModel.kt
@@ -1,11 +1,11 @@
 package jp.co.yumemi.android.code_check.repository.detail
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jp.co.yumemi.android.code_check.github.model.GithubRepoData
 import jp.co.yumemi.android.code_check.github.model.GithubRepoDataRepository
-import jp.co.yumemi.android.code_check.github.model.exampleGithubRepoData
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -17,18 +17,22 @@ class RepositoryDetailViewModel @Inject constructor(
     private val repoDataRepository: GithubRepoDataRepository,
 ) : ViewModel() {
     private val _repositoryUiState = MutableStateFlow(
-        RepositoryUiState(
-            repository = exampleGithubRepoData
-        )
+        RepositoryUiState.init
     )
     val repositoryUiState = _repositoryUiState.asStateFlow()
     fun initRepository(repoName: String) {
         viewModelScope.launch {
-            val repository = repoDataRepository.getRepoData(repoName)
-            _repositoryUiState.update {
-                it.copy(
-                    repository = repository,
-                )
+            try {
+                _repositoryUiState.update { it.toLoading() }
+                val repository = repoDataRepository.getRepoData(repoName)
+                if (repository == null) {
+                    _repositoryUiState.update { it.toError() }
+                    return@launch
+                }
+                _repositoryUiState.update { it.toSuccess(repository) }
+            } catch (e: Exception) {
+                Log.e("error", "init repository", e)
+                _repositoryUiState.update { it.toError() }
             }
         }
     }
@@ -36,4 +40,30 @@ class RepositoryDetailViewModel @Inject constructor(
 
 data class RepositoryUiState(
     val repository: GithubRepoData?,
-)
+    val isLoading: Boolean,
+    val isError: Boolean,
+) {
+    companion object {
+        val init = RepositoryUiState(
+            repository = null,
+            isLoading = true,
+            isError = false,
+        )
+    }
+
+    fun toLoading() = this.copy(
+        isLoading = true,
+        isError = false,
+    )
+
+    fun toSuccess(repository: GithubRepoData) = this.copy(
+        repository = repository,
+        isLoading = false,
+        isError = false,
+    )
+
+    fun toError() = this.copy(
+        isLoading = false,
+        isError = true,
+    )
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/search/Alert.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/search/Alert.kt
@@ -1,0 +1,47 @@
+package jp.co.yumemi.android.code_check.repository.search
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Icon
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.LocalTextStyle
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun Alert(
+    modifier: Modifier = Modifier,
+    iconContentDescription: String? = null,
+    text: @Composable () -> Unit,
+) {
+    val backgroundColor = MaterialTheme.colors.error
+    val contentColor = MaterialTheme.colors.onError
+
+    Row(
+        modifier = modifier
+            .padding(16.dp)
+            .background(backgroundColor)
+            .fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        CompositionLocalProvider(
+            LocalTextStyle provides LocalTextStyle.current.copy(color = contentColor),
+            LocalContentColor provides contentColor,
+        ) {
+            Icon(
+                Icons.Default.ErrorOutline,
+                contentDescription = iconContentDescription,
+                modifier = Modifier.padding(end = 12.dp),
+            )
+            text()
+        }
+    }
+}

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/search/RepositorySearchScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/search/RepositorySearchScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import jp.co.yumemi.android.code_check.R
+import jp.co.yumemi.android.code_check.components.Alert
 import jp.co.yumemi.android.code_check.github.model.GithubRepoData
 import jp.co.yumemi.android.code_check.github.model.exampleGithubRepoData
 import jp.co.yumemi.android.code_check.theme.CodeCheckTheme

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/search/RepositorySearchScreen.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/search/RepositorySearchScreen.kt
@@ -2,11 +2,14 @@ package jp.co.yumemi.android.code_check.repository.search
 
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
@@ -38,6 +41,8 @@ fun RepositorySearchScreen(
     RepositorySearchContent(
         searchQuery = text,
         onChangeSearchQuery = { searchViewModel.updateSearchQuery(it) },
+        isLoadingRepositories = repositoriesUiState.isSearching,
+        isError = repositoriesUiState.isError,
         repositories = repositoriesUiState.repositories,
         onSearchRepositories = { searchViewModel.searchRepository() },
         onClickRepository = { gotoRepositoryDetailScreen(it) },
@@ -48,6 +53,8 @@ fun RepositorySearchScreen(
 private fun RepositorySearchContent(
     searchQuery: String,
     onChangeSearchQuery: (String) -> Unit,
+    isLoadingRepositories: Boolean,
+    isError: Boolean,
     repositories: List<GithubRepoData>?,
     onSearchRepositories: () -> Unit,
     onClickRepository: (GithubRepoData) -> Unit,
@@ -61,6 +68,11 @@ private fun RepositorySearchContent(
                 .fillMaxSize()
                 .padding(it)
         ) {
+            if (isError) {
+                Alert {
+                    Text("エラーが発生しました...")
+                }
+            }
             Box(Modifier.padding(16.dp).fillMaxWidth()) {
                 SearchBar(
                     value = searchQuery,
@@ -69,19 +81,33 @@ private fun RepositorySearchContent(
                 )
             }
             if (repositories.isNullOrEmpty()) {
-                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    Text(
-                        if (repositories == null)
-                            "レポジトリを検索してね！"
-                        else
-                            "レポジトリがありません..."
-                    )
+                Row(
+                    Modifier.fillMaxSize(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    when (repositories) {
+                        null -> Text("レポジトリを検索してね！")
+                        else -> Text("レポジトリがありません...")
+                    }
+                    if (isLoadingRepositories) {
+                        CircularProgressIndicator()
+                    }
                 }
             } else {
-                RepositoryList(
-                    repositories = repositories,
-                    onClickRepository = onClickRepository,
-                )
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    if (isLoadingRepositories) {
+                        CircularProgressIndicator()
+                    } else {
+                        RepositoryList(
+                            repositories = repositories,
+                            onClickRepository = onClickRepository,
+                        )
+                    }
+                }
             }
         }
 
@@ -110,6 +136,8 @@ fun RepositorySearchContentPreview(
             searchQuery = "kotlin",
             onChangeSearchQuery = {},
             repositories = repositories,
+            isLoadingRepositories = false,
+            isError = false,
             onSearchRepositories = {},
             onClickRepository = {},
         )

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/search/RepositorySearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/repository/search/RepositorySearchViewModel.kt
@@ -24,7 +24,7 @@ class RepositorySearchViewModel @Inject constructor(
         RepositoriesUiState(
             isSearching = false,
             isError = false,
-            repositories = emptyList(),
+            repositories = null,
         )
     )
     val repositoriesUiState = _repositoriesUiState.asStateFlow()
@@ -62,5 +62,5 @@ class RepositorySearchViewModel @Inject constructor(
 data class RepositoriesUiState(
     val isSearching: Boolean,
     val isError: Boolean,
-    val repositories: List<GithubRepoData>,
+    val repositories: List<GithubRepoData>?,
 )


### PR DESCRIPTION
## 概要

エラーハンドリングおよびローディング表示を実装。

## 関連issue

#3 

## 変更点

- `material-icons-extended` を追加
- 検索画面と詳細画面にエラー表示やローディング表示を追加
- 詳細画面でスクロールできるように。
